### PR TITLE
feat: add open project button to WelcomeScreen

### DIFF
--- a/src/components/layout/MainEditor.tsx
+++ b/src/components/layout/MainEditor.tsx
@@ -3,27 +3,33 @@ import { useEditorStore } from '../../store/editorStore'
 import { Editor } from '../editor'
 import { openProjectViaDialog } from '../../lib/projects/actions'
 import { Button } from '../ui/button'
+import { useProjectStore } from '@/store/projectStore'
 
 // Welcome screen component for better organization
-const WelcomeScreen: React.FC = () => (
-  <div className="flex items-center justify-center h-full">
-    <div className="text-center text-muted-foreground flex flex-col gap-4">
-      <h2 className="m-0 text-2xl font-light">Welcome to Astro Editor</h2>
-      <p className="m-0 text-sm">
-        Select a project folder to get started, then choose a file to edit.
-      </p>
-      <Button
-        onClick={() => void openProjectViaDialog()}
-        className="self-center"
-        variant="outline"
-        size="sm"
-        title="Open Project"
-      >
-        Open Project
-      </Button>
+const WelcomeScreen: React.FC = () => {
+  const projectPath = useProjectStore(state => state.projectPath)
+  return (
+    <div className="flex items-center justify-center h-full">
+      <div className="text-center text-muted-foreground flex flex-col gap-4">
+        <h2 className="m-0 text-2xl font-light">Welcome to Astro Editor</h2>
+        <p className="m-0 text-sm">
+          Select a project folder to get started, then choose a file to edit.
+        </p>
+        {projectPath == null && (
+          <Button
+            onClick={() => void openProjectViaDialog()}
+            className="self-center"
+            variant="outline"
+            size="sm"
+            title="Open Project"
+          >
+            Open Project
+          </Button>
+        )}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export const MainEditor: React.FC = () => {
   // PERFORMANCE FIX: Use specific selector instead of currentFile object to avoid cascade


### PR DESCRIPTION
> As mentioned in https://github.com/dannysmith/astro-editor/issues/82#issuecomment-3857981616. I saw our timezone differences and wanted to open this in case, feel free to reject if this steps on the proper Projects UI work.

Simply adds an Open Project button to the Welcome Screen to clearly direct users to the intended first action.

<img width="1399" height="903" alt="image" src="https://github.com/user-attachments/assets/706a4f1a-a638-4107-b0e8-4b34d9e3b7ef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open Project" button to the Welcome screen, making it easier to open existing projects via a file dialog.

* **Style**
  * Refined Welcome screen layout, spacing, and heading alignment for improved visual organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->