### PR TITLE
Add Windows download button to website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -204,7 +204,7 @@
           "price": "0",
           "priceCurrency": "USD"
         },
-        "downloadUrl": "https://astroeditor.danny.is/astro-editor-latest.dmg",
+        "downloadUrl": "https://astroeditor.danny.is/",
         "screenshot": "https://astroeditor.danny.is/overview.png",
         "featureList": [
           "Schema-aware frontmatter forms",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows download support alongside existing macOS downloads.
  * Windows users can now download the Windows Installer directly from the site.
  * Updated platform availability to reflect macOS and Windows compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->