### PR TITLE
feat: add Linux download option to the website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -9,7 +9,7 @@
     </title>
     <meta
       name="description"
-      content="Transform your Astro content workflow with schema-aware frontmatter forms. Astro Editor reads your Zod schemas and creates intelligent editing interfaces for distraction-free markdown writing. Download for macOS and Windows."
+      content="Transform your Astro content workflow with schema-aware frontmatter forms. Astro Editor reads your Zod schemas and creates intelligent editing interfaces for distraction-free markdown writing. Download for macOS, Windows, and Linux."
     />
     <meta
       name="keywords"
@@ -191,7 +191,7 @@
         "@type": "SoftwareApplication",
         "name": "Astro Editor",
         "applicationCategory": "DeveloperApplication",
-        "operatingSystem": ["macOS", "Windows"],
+        "operatingSystem": ["macOS", "Windows", "Linux"],
         "description": "Schema-aware markdown editor for Astro content collections with intelligent frontmatter forms",
         "url": "https://astroeditor.danny.is/",
         "author": {
@@ -369,6 +369,32 @@
                 <div class="flex flex-col items-start">
                   <span>Download for Windows</span>
                   <span class="text-xs text-white/70 font-normal">Windows Installer</span>
+                </div>
+              </a>
+              <a
+                href="./astro-editor-latest.AppImage"
+                class="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-5 py-3 font-medium shadow-glow hover:bg-brand-500 transition"
+                aria-label="Download Astro Editor for Linux (AppImage)"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M12 3v12m0 0l4-4m-4 4l-4-4M4 18h16"
+                    stroke="white"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                <div class="flex flex-col items-start">
+                  <span>Download for Linux</span>
+                  <span class="text-xs text-white/70 font-normal">AppImage</span>
                 </div>
               </a>
             </div>


### PR DESCRIPTION
This pull request updates the website to add Linux support for the Astro Editor application. The most important changes include updating the website's metadata to mention Linux, adding Linux to the structured data, and providing a download link for the Linux AppImage.

**Website content and metadata updates:**

* Updated the meta description in `index.html` to mention that Astro Editor is available for macOS, Windows, and Linux.
* Added "Linux" to the `operatingSystem` array in the structured data (`@type: SoftwareApplication`) for better discoverability.

**Download options:**

* Added a new download button and section for the Linux AppImage in the downloads area, allowing users to download Astro Editor for Linux directly from the website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Linux as a supported platform to the website
  * Introduced a new Linux download option alongside existing macOS and Windows downloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->