### PR TITLE
Add Copy as Slug button to title fields

### DIFF
--- a/src/components/frontmatter/fields/CopyAsSlugLink.tsx
+++ b/src/components/frontmatter/fields/CopyAsSlugLink.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { commands } from '@/lib/bindings'
+import { slugFromTitle } from '@/lib/slug'
+
+interface CopyAsSlugLinkProps {
+  text: string
+}
+
+/**
+ * A tiny link rendered below the title field that copies the field's current
+ * contents to the clipboard as a URL slug. Renders nothing when the resulting
+ * slug would be empty.
+ */
+export const CopyAsSlugLink: React.FC<CopyAsSlugLinkProps> = ({ text }) => {
+  const slug = slugFromTitle(text)
+  if (!slug) return null
+
+  const handleClick = () => {
+    void (async () => {
+      try {
+        const result = await commands.copyTextToClipboard(slug)
+        if (result.status === 'error') {
+          throw new Error(result.error)
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to copy slug:', error)
+      }
+    })()
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="text-muted-foreground hover:text-foreground w-fit text-xs"
+    >
+      Copy as slug
+    </button>
+  )
+}

--- a/src/components/frontmatter/fields/FrontmatterField.tsx
+++ b/src/components/frontmatter/fields/FrontmatterField.tsx
@@ -218,6 +218,7 @@ export const FrontmatterField: React.FC<FrontmatterFieldProps> = ({
         maxRows={3}
         required={required}
         field={field}
+        showCopyAsSlug
       />
     )
   }

--- a/src/components/frontmatter/fields/TextareaField.tsx
+++ b/src/components/frontmatter/fields/TextareaField.tsx
@@ -3,6 +3,7 @@ import { useEditorStore } from '../../../store/editorStore'
 import { getNestedValue } from '../../../lib/object-utils'
 import { AutoExpandingTextarea } from '../../ui/auto-expanding-textarea'
 import { valueToString } from '../utils'
+import { CopyAsSlugLink } from './CopyAsSlugLink'
 import { FieldWrapper } from './FieldWrapper'
 import type { FieldProps } from '../../../types/common'
 import type { SchemaField } from '../../../lib/schema'
@@ -12,6 +13,7 @@ interface TextareaFieldProps extends FieldProps {
   minRows?: number
   maxRows?: number
   field?: SchemaField
+  showCopyAsSlug?: boolean
 }
 
 export const TextareaField: React.FC<TextareaFieldProps> = ({
@@ -23,6 +25,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
   maxRows = 6,
   required,
   field,
+  showCopyAsSlug = false,
 }) => {
   const value = useEditorStore(state => getNestedValue(state.frontmatter, name))
   const updateFrontmatterField = useEditorStore(
@@ -49,6 +52,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
         value={valueToString(value)}
         onChange={e => updateFrontmatterField(name, e.target.value)}
       />
+      {showCopyAsSlug && <CopyAsSlugLink text={valueToString(value)} />}
     </FieldWrapper>
   )
 }

--- a/src/lib/slug.test.ts
+++ b/src/lib/slug.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { slugFromTitle } from './slug'
+
+describe('slugFromTitle', () => {
+  it('returns an empty string for empty or whitespace-only input', () => {
+    expect(slugFromTitle('')).toBe('')
+    expect(slugFromTitle('   ')).toBe('')
+  })
+
+  it('lowercases and joins words with hyphens', () => {
+    expect(slugFromTitle('Hello World Example')).toBe('hello-world-example')
+  })
+
+  it('filters out common stop words', () => {
+    expect(slugFromTitle('The Quick Brown Fox')).toBe('quick-brown-fox')
+    expect(slugFromTitle('A Guide to the Galaxy')).toBe('guide-galaxy')
+  })
+
+  it('falls back to unfiltered words when every word is a stop word', () => {
+    expect(slugFromTitle('the and of')).toBe('the-and-of')
+  })
+
+  it('strips emoji and punctuation', () => {
+    expect(slugFromTitle('Hello, World! 🚀')).toBe('hello-world')
+    expect(slugFromTitle("It's a Test: Round #2")).toBe('test-round-2')
+  })
+
+  it('collapses existing hyphens and whitespace', () => {
+    expect(slugFromTitle('already-hyphenated   title')).toBe(
+      'already-hyphenated-title'
+    )
+  })
+
+  it('truncates a single very long word to the target length', () => {
+    const longWord = 'a'.repeat(80)
+    expect(slugFromTitle(longWord)).toBe('a'.repeat(50))
+  })
+
+  it('stops adding words once the target length is reached', () => {
+    const result = slugFromTitle(
+      'supercalifragilistic expialidocious additional words here'
+    )
+    expect(result.length).toBeLessThanOrEqual(50)
+    expect(result).toBe('supercalifragilistic-expialidocious-additional')
+  })
+
+  it('keeps digits', () => {
+    expect(slugFromTitle('Top 10 Tips for 2026')).toBe('top-10-tips-2026')
+  })
+})

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,116 @@
+// Utilities for generating URL slugs from human-readable text.
+
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'been',
+  'but',
+  'by',
+  'can',
+  'do',
+  'for',
+  'from',
+  'had',
+  'has',
+  'have',
+  'he',
+  'her',
+  'here',
+  'him',
+  'his',
+  'how',
+  'i',
+  'if',
+  'in',
+  'into',
+  'is',
+  'it',
+  'its',
+  'just',
+  'let',
+  'me',
+  'my',
+  'no',
+  'not',
+  'of',
+  'on',
+  'or',
+  'our',
+  'out',
+  'she',
+  'so',
+  'some',
+  'than',
+  'that',
+  'the',
+  'their',
+  'them',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'to',
+  'too',
+  'up',
+  'us',
+  'very',
+  'was',
+  'we',
+  'were',
+  'what',
+  'when',
+  'which',
+  'who',
+  'will',
+  'with',
+  'would',
+  'you',
+  'your',
+])
+
+const TARGET_LENGTH = 50
+
+/** Generate a URL slug from a title string.
+ *
+ * Strips emojis, punctuation, and common filler words, then takes enough
+ * full words to land near TARGET_LENGTH characters. Falls back to the raw
+ * cleaned words (without stop-word filtering) if every word is a stop word.
+ * Single very long words are truncated to TARGET_LENGTH.
+ */
+export function slugFromTitle(title: string): string {
+  // Strip emoji and non-alphanumeric (keep ASCII letters, digits, whitespace, hyphens)
+  const cleaned = title
+    .replace(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu, '')
+    .replace(/[^a-zA-Z0-9\s-]/g, '')
+    .toLowerCase()
+    .trim()
+
+  const allWords = cleaned.split(/[\s-]+/).filter(w => w.length > 0)
+  if (allWords.length === 0) return ''
+
+  const meaningful = allWords.filter(w => !STOP_WORDS.has(w))
+  // Fall back to unfiltered words if every word was a stop word.
+  const words = meaningful.length > 0 ? meaningful : allWords
+
+  if (words.length === 1) {
+    return (words[0] ?? '').slice(0, TARGET_LENGTH)
+  }
+
+  const result: string[] = []
+  let len = 0
+
+  for (const word of words) {
+    const added = result.length > 0 ? word.length + 1 : word.length
+    if (len + added > TARGET_LENGTH && result.length > 0) break
+    result.push(word)
+    len += added
+  }
+
+  return result.join('-')
+}


### PR DESCRIPTION
Adds a small "Copy as slug" button to title fields in the frontmatter panel, which copies the contents of it to th clipboard, appropriatley slugified.

Intended as a minor UX improvement when renaming files or adding a slug field.

May eventually be replaced or altered as part of work on #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy as slug" button to the title field. Clicking the button generates a URL-friendly slug from your title and copies it to the clipboard for easy reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->