### PR TITLE
Add astro-editor:// URL scheme to open files

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@tanstack/react-query": "^5.100.14",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-log": "^2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.2
         version: 2.3.2
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -2463,6 +2466,9 @@ packages:
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -8520,6 +8526,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -180,12 +180,14 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tauri-specta",
@@ -779,6 +781,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1119,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2051,7 +2082,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -3090,6 +3121,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,6 +3954,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -5064,6 +5115,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5175,6 +5247,22 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -5461,6 +5549,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -6475,6 +6572,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,8 @@ reqwest = { version = "0.13", features = ["json"] }
 uuid = { version = "1.23", features = ["v4"] }
 tauri-plugin-os = "2.3.2"
 tauri-plugin-window-state = "2"
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,9 @@
     "core:window:allow-set-fullscreen",
     "core:window:allow-is-fullscreen",
     "core:window:allow-hide",
+    "core:window:allow-show",
+    "core:window:allow-set-focus",
+    "core:window:allow-unminimize",
     "core:path:default",
     "core:menu:default",
     "opener:default",
@@ -42,6 +45,7 @@
     "log:default",
     "os:default",
     "window-state:default",
+    "deep-link:default",
     {
       "identifier": "fs:scope",
       "allow": [

--- a/src-tauri/src/bindings.rs
+++ b/src-tauri/src/bindings.rs
@@ -43,6 +43,7 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         crate::commands::project::select_project_folder,
         crate::commands::project::scan_project,
         crate::commands::project::scan_project_with_content_dir,
+        crate::commands::project::resolve_file_entry,
         crate::commands::project::scan_collection_files,
         crate::commands::project::load_file_based_collection,
         crate::commands::project::read_json_schema,

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -793,6 +793,74 @@ pub async fn scan_collection_files_recursive(
     collect_files_recursive(&path, &collection_name, &collection_root)
 }
 
+/// Resolves an absolute file path to a `FileEntry` within the given project, if the
+/// file is a Markdown/MDX item owned by one of the project's content collections.
+///
+/// Used by the deep-link handler (`astro-editor://open?path=...`). `file_path` is
+/// untrusted input, so we canonicalize and verify it lives inside `project_path`
+/// before touching collections, guarding against `../` traversal.
+///
+/// Returns `Ok(None)` when the path is valid and inside the project but isn't a
+/// Markdown item owned by a loadable collection (the caller opens the project and
+/// shows a "couldn't find that file" toast).
+#[tauri::command]
+#[specta::specta]
+pub async fn resolve_file_entry(
+    file_path: String,
+    project_path: String,
+    content_directory: Option<String>,
+) -> Result<Option<FileEntry>, String> {
+    // Canonicalize the project root (must exist).
+    let project_canon =
+        std::fs::canonicalize(&project_path).map_err(|e| format!("Invalid project path: {e}"))?;
+
+    // Canonicalize the target file. A missing file resolves to None (not an error).
+    let file_canon = match std::fs::canonicalize(&file_path) {
+        Ok(p) => p,
+        Err(_) => return Ok(None),
+    };
+
+    // Security: the file must live inside the project root.
+    if !file_canon.starts_with(&project_canon) {
+        return Err("File is not inside the project".to_string());
+    }
+
+    // Only Markdown/MDX files are openable.
+    let is_markdown = file_canon
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("md") || e.eq_ignore_ascii_case("mdx"))
+        .unwrap_or(false);
+    if !is_markdown {
+        return Ok(None);
+    }
+
+    // Reuse the existing project scan to discover collections and their roots.
+    let collections = scan_project_with_content_dir(project_path, content_directory).await?;
+
+    // Find the collection whose directory is the most specific ancestor of the file.
+    let owning = collections
+        .into_iter()
+        .filter_map(|collection| {
+            let collection_canon = std::fs::canonicalize(&collection.path).ok()?;
+            if file_canon.starts_with(&collection_canon) {
+                Some((collection_canon, collection))
+            } else {
+                None
+            }
+        })
+        .max_by_key(|(canon, _)| canon.as_os_str().len());
+
+    match owning {
+        Some((collection_canon, collection)) => Ok(Some(FileEntry::new(
+            file_canon,
+            collection.name,
+            collection_canon,
+        ))),
+        None => Ok(None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -972,5 +1040,163 @@ mod tests {
                 "MicrosoftEdge should NOT be blocked (no trailing slash match)"
             );
         }
+    }
+
+    // --- resolve_file_entry tests ---
+
+    /// Creates a temp project with a `src/content/<collection>/<relative>` markdown
+    /// file and returns the temp dir plus the absolute file path.
+    fn make_project_with_file(relative: &str) -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let file_path = temp.path().join("src").join("content").join(relative);
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        std::fs::write(&file_path, "# Hello\n").unwrap();
+        (temp, file_path)
+    }
+
+    #[tokio::test]
+    async fn test_resolve_file_entry_happy_path() {
+        let (temp, file_path) = make_project_with_file("blog/post.md");
+
+        let result = resolve_file_entry(
+            file_path.to_string_lossy().to_string(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let entry = result.expect("expected the file to resolve");
+        assert_eq!(entry.collection, "blog");
+        assert_eq!(entry.name, "post");
+        assert_eq!(entry.extension, "md");
+        assert_eq!(entry.id, "blog/post");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_file_entry_nested_path() {
+        let (temp, file_path) = make_project_with_file("blog/2024/january/post.mdx");
+
+        let result = resolve_file_entry(
+            file_path.to_string_lossy().to_string(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let entry = result.expect("expected the nested file to resolve");
+        assert_eq!(entry.collection, "blog");
+        assert_eq!(entry.extension, "mdx");
+        assert_eq!(entry.id, "blog/2024/january/post");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_file_entry_outside_project_is_rejected() {
+        // File lives in a completely separate directory.
+        let other = tempfile::TempDir::new().unwrap();
+        let outside_file = other.path().join("secret.md");
+        std::fs::write(&outside_file, "secret").unwrap();
+
+        let project = tempfile::TempDir::new().unwrap();
+
+        let result = resolve_file_entry(
+            outside_file.to_string_lossy().to_string(),
+            project.path().to_string_lossy().to_string(),
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "file outside the project must be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_file_entry_traversal_is_rejected() {
+        // A `..` path that escapes the project root must be rejected after canonicalization.
+        let parent = tempfile::TempDir::new().unwrap();
+        let project_dir = parent.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let secret = parent.path().join("secret.md");
+        std::fs::write(&secret, "secret").unwrap();
+
+        let traversal = project_dir.join("..").join("secret.md");
+
+        let result = resolve_file_entry(
+            traversal.to_string_lossy().to_string(),
+            project_dir.to_string_lossy().to_string(),
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "path traversal must be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_file_entry_non_markdown_returns_none() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let file_path = temp
+            .path()
+            .join("src")
+            .join("content")
+            .join("blog")
+            .join("data.json");
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        std::fs::write(&file_path, "{}").unwrap();
+
+        let result = resolve_file_entry(
+            file_path.to_string_lossy().to_string(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.is_none(),
+            "non-markdown files should resolve to None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_file_entry_nonexistent_returns_none() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let missing = temp
+            .path()
+            .join("src")
+            .join("content")
+            .join("blog")
+            .join("ghost.md");
+
+        let result = resolve_file_entry(
+            missing.to_string_lossy().to_string(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.is_none(), "missing files should resolve to None");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_file_entry_not_in_collection_returns_none() {
+        // A markdown file inside the project but outside any content collection.
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(temp.path().join("src").join("content").join("blog")).unwrap();
+        let readme = temp.path().join("README.md");
+        std::fs::write(&readme, "# Readme").unwrap();
+
+        let result = resolve_file_entry(
+            readme.to_string_lossy().to_string(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.is_none(),
+            "markdown outside a collection should resolve to None"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,7 +45,27 @@ pub fn run() {
 
     let builder = bindings::generate_bindings();
 
-    tauri::Builder::default()
+    #[allow(unused_mut)]
+    let mut tauri_builder = tauri::Builder::default();
+
+    // The single-instance plugin MUST be registered first. On Windows/Linux a deep
+    // link spawns a new process with the URL as a CLI argument; this plugin forwards
+    // that to the already-running instance (via the `deep-link` feature) and focuses
+    // it, instead of opening a second window. macOS is already single-instance.
+    #[cfg(desktop)]
+    {
+        tauri_builder =
+            tauri_builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.unminimize();
+                    let _ = window.set_focus();
+                }
+            }));
+    }
+
+    tauri_builder
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -84,6 +84,11 @@
     }
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["astro-editor"]
+      }
+    },
     "opener": {
       "requireLiteralLeadingDot": false
     },

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -23,6 +23,7 @@ import { useEditorFileContent } from '../../hooks/useEditorFileContent'
 import { useFileChangeHandler } from '../../hooks/useFileChangeHandler'
 import { useEditorActions } from '../../hooks/editor/useEditorActions'
 import { useCreateFile } from '../../hooks/useCreateFile'
+import { useDeepLink } from '../../hooks/useDeepLink'
 import { useSquareCornersEffect } from '../../hooks/useSquareCornersEffect'
 import { useEditorStore } from '../../store/editorStore'
 import { focusEditor } from '../../lib/focus-utils'
@@ -110,7 +111,7 @@ export const Layout: React.FC = () => {
   }, [])
 
   // Get editor actions (Hybrid Action Hooks pattern)
-  const { saveFile } = useEditorActions()
+  const { saveFile, openFileByPath } = useEditorActions()
   const { createNewFile: createNewFileWithQuery } = useCreateFile()
 
   // Register auto-save callback with store
@@ -129,6 +130,7 @@ export const Layout: React.FC = () => {
   useMenuEvents(createNewFileWithQuery, handleSetPreferencesOpen)
   useSquareCornersEffect()
   useDOMEventListeners(createNewFileWithQuery, handleSetPreferencesOpen)
+  useDeepLink(openFileByPath)
 
   // Enable query-based file loading
   useEditorFileContent()

--- a/src/hooks/editor/useEditorActions.ts
+++ b/src/hooks/editor/useEditorActions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { info, error as logError } from '@tauri-apps/plugin-log'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import { useQueryClient } from '@tanstack/react-query'
 import { commands, type Collection, type JsonValue } from '@/types'
 import { useEditorStore } from '../../store/editorStore'
@@ -8,6 +9,52 @@ import { saveRecoveryData, saveCrashReport } from '../../lib/recovery'
 import { toast } from '../../lib/toast'
 import { queryKeys } from '../../lib/query-keys'
 import { deserializeCompleteSchema } from '../../lib/schema'
+import {
+  projectRegistryManager,
+  getEffectiveContentDirectory,
+} from '../../lib/project-registry'
+import { findOwningProjectPath } from '../../lib/deep-link'
+import { ASTRO_PATHS } from '../../lib/constants'
+
+/**
+ * Waits until the project store reflects `targetPath` as the active project with
+ * its settings loaded. Resolves `false` if that doesn't happen within `timeoutMs`.
+ *
+ * `setProject` is fire-and-forget, so deep-link handling must wait for the switch
+ * to complete before resolving/opening a file in the new project.
+ */
+function waitForProjectReady(
+  targetPath: string,
+  timeoutMs = 8000
+): Promise<boolean> {
+  const state = useProjectStore.getState()
+  if (state.projectPath === targetPath && state.currentProjectSettings) {
+    return Promise.resolve(true)
+  }
+
+  return new Promise<boolean>(resolve => {
+    const handles: {
+      unsubscribe?: () => void
+      timer?: ReturnType<typeof setTimeout>
+    } = {}
+
+    handles.timer = setTimeout(() => {
+      handles.unsubscribe?.()
+      resolve(false)
+    }, timeoutMs)
+
+    handles.unsubscribe = useProjectStore.subscribe(current => {
+      if (
+        current.projectPath === targetPath &&
+        current.currentProjectSettings
+      ) {
+        clearTimeout(handles.timer)
+        handles.unsubscribe?.()
+        resolve(true)
+      }
+    })
+  })
+}
 
 /**
  * Editor action hooks following the Hybrid Action Hooks pattern.
@@ -161,5 +208,93 @@ export function useEditorActions() {
     [queryClient]
   )
 
-  return { saveFile }
+  /**
+   * Opens a file from an `astro-editor://open?path=...` deep link.
+   *
+   * Resolves the file against the *known* projects (the registry), switching
+   * projects if needed, then reuses `openFile` — the same path the sidebar uses.
+   */
+  const openFileByPath = useCallback(async (filePath: string) => {
+    // Bring the window forward immediately so the app visibly responds.
+    try {
+      const win = getCurrentWindow()
+      await win.show()
+      await win.unminimize()
+      await win.setFocus()
+    } catch {
+      // Best-effort — focusing should never block opening the file.
+    }
+
+    // Only Markdown/MDX files are openable.
+    const lower = filePath.toLowerCase()
+    if (!lower.endsWith('.md') && !lower.endsWith('.mdx')) {
+      toast.error('Astro Editor can only open .md or .mdx files')
+      return
+    }
+
+    // Find the known project that owns this file (initializing the registry if
+    // this is a cold start that raced ahead of normal initialization).
+    let knownProjectPaths: string[]
+    try {
+      knownProjectPaths = Object.values(
+        projectRegistryManager.getRegistry().projects
+      ).map(p => p.path)
+    } catch {
+      await projectRegistryManager.initialize()
+      knownProjectPaths = Object.values(
+        projectRegistryManager.getRegistry().projects
+      ).map(p => p.path)
+    }
+
+    const owningProjectPath = findOwningProjectPath(knownProjectPaths, filePath)
+    if (!owningProjectPath) {
+      toast.error("That file isn't in a project Astro Editor knows about", {
+        description:
+          'Open the project once, then links to its files will work.',
+      })
+      return
+    }
+
+    // Switch to the owning project if it isn't already active, then wait for it.
+    const isCurrentProject =
+      useProjectStore.getState().projectPath === owningProjectPath
+    if (!isCurrentProject) {
+      useProjectStore.getState().setProject(owningProjectPath)
+      const ready = await waitForProjectReady(owningProjectPath)
+      if (!ready) {
+        toast.error('Failed to open the project for that link')
+        return
+      }
+    }
+
+    // Resolve the file to a FileEntry within the project (reuses the Rust scan).
+    const { currentProjectSettings } = useProjectStore.getState()
+    const contentDirectory = getEffectiveContentDirectory(
+      currentProjectSettings
+    )
+    const result = await commands.resolveFileEntry(
+      filePath,
+      owningProjectPath,
+      contentDirectory !== ASTRO_PATHS.CONTENT_DIR ? contentDirectory : null
+    )
+
+    if (result.status === 'error') {
+      toast.error("Couldn't open that file", { description: result.error })
+      await logError(`Deep link resolve failed: ${result.error}`)
+      return
+    }
+
+    if (!result.data) {
+      // Project is now open, but the file isn't part of a loadable collection.
+      toast.warning("Couldn't find that file in the project", {
+        description: 'It may not be part of a content collection.',
+      })
+      return
+    }
+
+    useEditorStore.getState().openFile(result.data)
+    await info(`Deep link opened file: ${result.data.id}`)
+  }, [])
+
+  return { saveFile, openFileByPath }
 }

--- a/src/hooks/useDeepLink.ts
+++ b/src/hooks/useDeepLink.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react'
+import { onOpenUrl, getCurrent } from '@tauri-apps/plugin-deep-link'
+import { error as logError } from '@tauri-apps/plugin-log'
+import { parseDeepLinkPath, resolveDeepLinkStartup } from '../lib/deep-link'
+
+/**
+ * Wires up the `astro-editor://open?path=...` URL scheme.
+ *
+ * Handles two cases:
+ * - **Warm** (app already running): `onOpenUrl` fires with the incoming URL(s).
+ * - **Cold start** (app launched *by* the link): `onOpenUrl` does not fire for
+ *   the launch URL, so we read it once via `getCurrent()`.
+ *
+ * On cold start we also signal `resolveDeepLinkStartup` so the persisted-project
+ * loader yields to the deep link's target project (see `loadPersistedProject`).
+ */
+export function useDeepLink(openFileByPath: (path: string) => Promise<void>) {
+  // Capture the latest callback in a ref so listeners are set up only once
+  // (mirrors useMenuEvents) — re-registering would re-process the launch URL.
+  const openFileByPathRef = useRef(openFileByPath)
+
+  useEffect(() => {
+    openFileByPathRef.current = openFileByPath
+  }, [openFileByPath])
+
+  useEffect(() => {
+    let cancelled = false
+    let unlisten: (() => void) | undefined
+
+    const handleUrl = async (url: string) => {
+      const path = parseDeepLinkPath(url)
+      if (path) {
+        await openFileByPathRef.current(path)
+      }
+    }
+
+    const setup = async () => {
+      // Cold start: retrieve the launch URL(s), if any.
+      try {
+        const launchUrls = await getCurrent()
+        const openUrls = (launchUrls ?? []).filter(
+          url => parseDeepLinkPath(url) !== null
+        )
+
+        // Let the persisted-project loader know whether to stand down.
+        resolveDeepLinkStartup(openUrls.length > 0)
+
+        if (!cancelled) {
+          for (const url of openUrls) {
+            await handleUrl(url)
+          }
+        }
+      } catch (e) {
+        // No launch URL / plugin unavailable — fall back to normal startup.
+        resolveDeepLinkStartup(false)
+        await logError(`Deep link getCurrent failed: ${String(e)}`)
+      }
+
+      // Warm: handle subsequent deep links while the app is running.
+      try {
+        unlisten = await onOpenUrl(urls => {
+          for (const url of urls) {
+            void handleUrl(url)
+          }
+        })
+      } catch (e) {
+        await logError(`Deep link onOpenUrl registration failed: ${String(e)}`)
+      }
+    }
+
+    void setup()
+
+    return () => {
+      cancelled = true
+      unlisten?.()
+    }
+  }, [])
+}

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -239,6 +239,26 @@ async scanProjectWithContentDir(projectPath: string, contentDirectory: string | 
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Resolves an absolute file path to a `FileEntry` within the given project, if the
+ * file is a Markdown/MDX item owned by one of the project's content collections.
+ * 
+ * Used by the deep-link handler (`astro-editor://open?path=...`). `file_path` is
+ * untrusted input, so we canonicalize and verify it lives inside `project_path`
+ * before touching collections, guarding against `../` traversal.
+ * 
+ * Returns `Ok(None)` when the path is valid and inside the project but isn't a
+ * Markdown item owned by a loadable collection (the caller opens the project and
+ * shows a "couldn't find that file" toast).
+ */
+async resolveFileEntry(filePath: string, projectPath: string, contentDirectory: string | null) : Promise<Result<FileEntry | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("resolve_file_entry", { filePath, projectPath, contentDirectory }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async scanCollectionFiles(collectionPath: string) : Promise<Result<FileEntry[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("scan_collection_files", { collectionPath }) };

--- a/src/lib/deep-link.test.ts
+++ b/src/lib/deep-link.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { parseDeepLinkPath, findOwningProjectPath } from './deep-link'
+
+describe('parseDeepLinkPath', () => {
+  it('extracts and decodes the path from a valid open URL', () => {
+    const url =
+      'astro-editor://open?path=/Users/danny/dev/blog/src/content/blog/post.md'
+    expect(parseDeepLinkPath(url)).toBe(
+      '/Users/danny/dev/blog/src/content/blog/post.md'
+    )
+  })
+
+  it('decodes percent-encoded paths (spaces and special chars)', () => {
+    const url =
+      'astro-editor://open?path=%2FUsers%2Fdanny%2Fmy%20blog%2Fa%20post.md'
+    expect(parseDeepLinkPath(url)).toBe('/Users/danny/my blog/a post.md')
+  })
+
+  it('returns null for a different scheme', () => {
+    expect(parseDeepLinkPath('other-app://open?path=/x.md')).toBeNull()
+  })
+
+  it('returns null for an unknown action/host', () => {
+    expect(parseDeepLinkPath('astro-editor://close?path=/x.md')).toBeNull()
+  })
+
+  it('returns null when path is missing or empty', () => {
+    expect(parseDeepLinkPath('astro-editor://open')).toBeNull()
+    expect(parseDeepLinkPath('astro-editor://open?path=')).toBeNull()
+  })
+
+  it('returns null for malformed URLs', () => {
+    expect(parseDeepLinkPath('not a url')).toBeNull()
+  })
+})
+
+describe('findOwningProjectPath', () => {
+  const projects = ['/Users/danny/dev/blog', '/Users/danny/dev/docs-site']
+
+  it('finds the project that owns the file', () => {
+    expect(
+      findOwningProjectPath(
+        projects,
+        '/Users/danny/dev/blog/src/content/blog/post.md'
+      )
+    ).toBe('/Users/danny/dev/blog')
+  })
+
+  it('returns null when no known project owns the file', () => {
+    expect(
+      findOwningProjectPath(projects, '/Users/danny/other/file.md')
+    ).toBeNull()
+  })
+
+  it('does not match on a partial path-segment prefix', () => {
+    // /Users/danny/dev/blog-archive should not match /Users/danny/dev/blog
+    expect(
+      findOwningProjectPath(
+        projects,
+        '/Users/danny/dev/blog-archive/src/content/x.md'
+      )
+    ).toBeNull()
+  })
+
+  it('prefers the most specific (longest) matching project', () => {
+    const nested = ['/Users/danny/dev', '/Users/danny/dev/blog']
+    expect(
+      findOwningProjectPath(nested, '/Users/danny/dev/blog/src/content/x.md')
+    ).toBe('/Users/danny/dev/blog')
+  })
+
+  it('tolerates trailing slashes on the project path', () => {
+    expect(
+      findOwningProjectPath(
+        ['/Users/danny/dev/blog/'],
+        '/Users/danny/dev/blog/src/content/x.md'
+      )
+    ).toBe('/Users/danny/dev/blog/')
+  })
+
+  it('matches case-insensitively and across separators', () => {
+    expect(
+      findOwningProjectPath(
+        ['C:\\Users\\Danny\\Blog'],
+        'c:/users/danny/blog/src/content/x.md'
+      )
+    ).toBe('C:\\Users\\Danny\\Blog')
+  })
+})

--- a/src/lib/deep-link.ts
+++ b/src/lib/deep-link.ts
@@ -1,0 +1,102 @@
+/**
+ * Deep-link helpers for the `astro-editor://open?path=...` URL scheme.
+ *
+ * Pure parsing/matching logic lives here (testable, no Tauri/store deps). The
+ * cold-start coordination below lets an incoming launch URL take precedence over
+ * the persisted-project auto-load (see `loadPersistedProject` in projectStore).
+ */
+
+/** The custom URL scheme this app registers (matches tauri.conf.json). */
+const SCHEME = 'astro-editor:'
+
+/** The only supported action/host for now. */
+const OPEN_ACTION = 'open'
+
+/**
+ * Parses an `astro-editor://open?path=<encoded-path>` URL and returns the decoded
+ * absolute file path, or `null` if the URL isn't a valid open-file deep link.
+ */
+export function parseDeepLinkPath(url: string): string | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== SCHEME) return null
+  if (parsed.host !== OPEN_ACTION) return null
+
+  // searchParams already percent-decodes the value.
+  const path = parsed.searchParams.get('path')
+  if (!path || path.trim() === '') return null
+
+  return path
+}
+
+function normalizeForCompare(p: string): string {
+  return p.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+/**
+ * Returns the project path (from the given list of known project paths) that owns
+ * `filePath`, i.e. is an ancestor of it. The most specific (longest) match wins.
+ * Comparison is case-insensitive and separator-agnostic to tolerate
+ * macOS/Windows path quirks; the Rust layer enforces real containment.
+ *
+ * Returns the original (un-normalized) project path so it can be passed to
+ * `setProject`, or `null` if no known project owns the file.
+ */
+export function findOwningProjectPath(
+  projectPaths: string[],
+  filePath: string
+): string | null {
+  const file = normalizeForCompare(filePath).toLowerCase()
+
+  let best: string | null = null
+  let bestLength = -1
+
+  for (const projectPath of projectPaths) {
+    const parent = normalizeForCompare(projectPath)
+    const parentCmp = parent.toLowerCase()
+
+    const isInside = file === parentCmp || file.startsWith(`${parentCmp}/`)
+    if (isInside && parent.length > bestLength) {
+      best = projectPath
+      bestLength = parent.length
+    }
+  }
+
+  return best
+}
+
+// --- Cold-start coordination -------------------------------------------------
+
+let resolveStartupClaim: ((claimed: boolean) => void) | null = null
+const startupClaim = new Promise<boolean>(resolve => {
+  resolveStartupClaim = resolve
+})
+
+/**
+ * Called once by the deep-link hook after it has checked for a launch URL.
+ * `claimed` is true when the app was started by a deep link (so the deep-link
+ * handler — not the persisted-project loader — should decide which project opens).
+ */
+export function resolveDeepLinkStartup(claimed: boolean): void {
+  resolveStartupClaim?.(claimed)
+  resolveStartupClaim = null
+}
+
+/**
+ * Resolves to `true` if a deep link claimed app startup, `false` otherwise.
+ * Bounded by `timeoutMs` so the persisted-project loader never hangs if the
+ * deep-link hook didn't run (e.g. plugin unavailable).
+ */
+export function wasStartupClaimedByDeepLink(
+  timeoutMs = 2000
+): Promise<boolean> {
+  const fallback = new Promise<boolean>(resolve => {
+    setTimeout(() => resolve(false), timeoutMs)
+  })
+  return Promise.race([startupClaim, fallback])
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -14,6 +14,7 @@ import {
 import { useEditorStore } from './editorStore'
 import { queryClient } from '../lib/query-client'
 import { queryKeys } from '../lib/query-keys'
+import { wasStartupClaimedByDeepLink } from '../lib/deep-link'
 
 interface ProjectState {
   // Core identifiers
@@ -295,6 +296,16 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   loadPersistedProject: async () => {
     try {
       await get().initializeProjectRegistry()
+
+      // If the app was launched by a deep link, let it choose which project to
+      // open instead of restoring the last one (avoids opening the wrong project
+      // then switching). Bounded wait so we never hang on normal startup.
+      if (await wasStartupClaimedByDeepLink()) {
+        await info(
+          'Astro Editor [PROJECT_SETUP] Deep link claimed startup - skipping persisted project load'
+        )
+        return
+      }
 
       // Try to load the last opened project from registry
       const lastProjectId = projectRegistryManager.getLastOpenedProjectId()


### PR DESCRIPTION
Adds an `astro-editor://open?path=<abs-path>` deep link to open a file from other apps or the OS.

- Launches the app if needed, switches to the owning **known** project, opens the file (reusing the sidebar's path)
- Cross-platform: `single-instance` routes links to the running window on Windows/Linux like macOS already does
- Path is validated/canonicalized in Rust (must live inside a known project)

Closes #240

> [!NOTE]
> Deep links only work in a packaged build (not `tauri dev`). Test: `tauri build` → install to `/Applications` → `open "astro-editor://open?path=/abs/file.md"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deep-link support: Open files directly in the editor using `astro-editor://` URLs from external applications.
  * Implemented single-instance mode: Ensures only one application window is active at any time.

* **Chores**
  * Added required dependencies and configuration for deep-link and single-instance functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->