### PR TITLE
Add GFM support for MD/MDX highlighting of tables, checklists etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@codemirror/view": "^6.43.0",
     "@hookform/resolvers": "^5.4.0",
     "@lezer/highlight": "^1.2.3",
+    "@lezer/markdown": "1.6.4",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.8",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@lezer/markdown':
+        specifier: 1.6.4
+        version: 1.6.4
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/src/lib/editor/extensions/createExtensions.ts
+++ b/src/lib/editor/extensions/createExtensions.ts
@@ -39,6 +39,7 @@
 
 import { EditorView, dropCursor, drawSelection } from '@codemirror/view'
 import { markdown } from '@codemirror/lang-markdown'
+import { GFM } from '@lezer/markdown'
 import { syntaxHighlighting } from '@codemirror/language'
 import { history } from '@codemirror/commands'
 import { closeBrackets } from '@codemirror/autocomplete'
@@ -84,8 +85,12 @@ export const createExtensions = (config: ExtensionConfig) => {
     ),
 
     // Language support
+    // GFM enables tables, task lists, strikethrough, and autolinks (issue #266).
+    // We add the GFM bundle rather than switching to `base: markdownLanguage`
+    // so we get GFM only, without subscript/superscript/emoji (single `~x~`
+    // would otherwise become subscript, which is hostile to prose writing).
     markdown({
-      extensions: [markdownStyleExtension],
+      extensions: [markdownStyleExtension, GFM],
     }),
     syntaxHighlighting(comprehensiveHighlightStyle),
     history(),


### PR DESCRIPTION
Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Markdown editing support with GitHub Flavored Markdown (GFM) capabilities.
  * Added a required Markdown parsing dependency to support the enhanced editor experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->