### PR TITLE
Ensure all external URLs open in OS browser not in the Tauri window

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -25,6 +25,7 @@ import { useEditorActions } from '../../hooks/editor/useEditorActions'
 import { useCreateFile } from '../../hooks/useCreateFile'
 import { useDeepLink } from '../../hooks/useDeepLink'
 import { useSquareCornersEffect } from '../../hooks/useSquareCornersEffect'
+import { useExternalLinkHandler } from '../../hooks/useExternalLinkHandler'
 import { useEditorStore } from '../../store/editorStore'
 import { focusEditor } from '../../lib/focus-utils'
 import { commands } from '../../lib/bindings'
@@ -131,6 +132,7 @@ export const Layout: React.FC = () => {
   useSquareCornersEffect()
   useDOMEventListeners(createNewFileWithQuery, handleSetPreferencesOpen)
   useDeepLink(openFileByPath)
+  useExternalLinkHandler()
 
   // Enable query-based file loading
   useEditorFileContent()

--- a/src/hooks/useExternalLinkHandler.ts
+++ b/src/hooks/useExternalLinkHandler.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { error as logError } from '@tauri-apps/plugin-log'
-import { getExternalUrlFromClick } from '../lib/external-links'
+import { classifyLinkClick } from '../lib/external-links'
 
 /**
  * App-wide safety net that routes external links to the OS default browser.
@@ -16,16 +16,19 @@ import { getExternalUrlFromClick } from '../lib/external-links'
 export function useExternalLinkHandler() {
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
-      const url = getExternalUrlFromClick(event)
-      if (!url) return
+      const action = classifyLinkClick(event)
+      if (action.type === 'ignore') return
 
-      // We fully handle external links here. Stop propagation so component-level
-      // handlers (e.g. DocsLink) don't also fire and open the URL twice.
+      // We fully handle external/blocked links here. Stop propagation so
+      // component-level handlers (e.g. DocsLink) don't also fire.
       event.preventDefault()
       event.stopPropagation()
-      void openUrl(url).catch(err => {
-        void logError(`Failed to open external URL: ${String(err)}`)
-      })
+
+      if (action.type === 'open') {
+        void openUrl(action.url).catch(err => {
+          void logError(`Failed to open external URL: ${String(err)}`)
+        })
+      }
     }
 
     // Capture phase so we intercept before any component-level navigation.

--- a/src/hooks/useExternalLinkHandler.ts
+++ b/src/hooks/useExternalLinkHandler.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { openUrl } from '@tauri-apps/plugin-opener'
+import { error as logError } from '@tauri-apps/plugin-log'
+import { getExternalUrlFromClick } from '../lib/external-links'
+
+/**
+ * App-wide safety net that routes external links to the OS default browser.
+ *
+ * Registers a single capturing click listener on the document. Any click on an
+ * external link (e.g. inside update release notes rendered via
+ * `dangerouslySetInnerHTML`) is intercepted and opened in the user's default
+ * browser instead of navigating the Tauri webview away from the app.
+ *
+ * See `lib/external-links.ts` for the link-classification logic.
+ */
+export function useExternalLinkHandler() {
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      const url = getExternalUrlFromClick(event)
+      if (!url) return
+
+      // We fully handle external links here. Stop propagation so component-level
+      // handlers (e.g. DocsLink) don't also fire and open the URL twice.
+      event.preventDefault()
+      event.stopPropagation()
+      void openUrl(url).catch(err => {
+        void logError(`Failed to open external URL: ${String(err)}`)
+      })
+    }
+
+    // Capture phase so we intercept before any component-level navigation.
+    document.addEventListener('click', handleClick, true)
+    return () => document.removeEventListener('click', handleClick, true)
+  }, [])
+}

--- a/src/lib/external-links.test.ts
+++ b/src/lib/external-links.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { getExternalUrlFromClick } from './external-links'
+
+/**
+ * Build a minimal MouseEvent-like object whose `target` is a real DOM element,
+ * so the production code's `closest('a')`/`protocol`/`origin` logic runs for
+ * real. Defaults represent an unmodified primary-button click.
+ */
+function clickEvent(
+  target: EventTarget | null,
+  overrides: Partial<MouseEvent> = {}
+): MouseEvent {
+  return {
+    defaultPrevented: false,
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    target,
+    ...overrides,
+  } as unknown as MouseEvent
+}
+
+function makeAnchor(href: string): HTMLAnchorElement {
+  const a = document.createElement('a')
+  a.href = href
+  document.body.appendChild(a)
+  return a
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('getExternalUrlFromClick', () => {
+  it('returns the URL for an external https link', () => {
+    const a = makeAnchor('https://example.com/page')
+    expect(getExternalUrlFromClick(clickEvent(a))).toBe(
+      'https://example.com/page'
+    )
+  })
+
+  it('returns the URL for an external http link', () => {
+    const a = makeAnchor('http://example.com/')
+    expect(getExternalUrlFromClick(clickEvent(a))).toBe('http://example.com/')
+  })
+
+  it('returns the URL for mailto and tel links', () => {
+    const mail = makeAnchor('mailto:hi@danny.is')
+    expect(getExternalUrlFromClick(clickEvent(mail))).toBe('mailto:hi@danny.is')
+
+    const tel = makeAnchor('tel:+15551234567')
+    expect(getExternalUrlFromClick(clickEvent(tel))).toBe('tel:+15551234567')
+  })
+
+  it('resolves clicks on elements nested inside the anchor', () => {
+    const a = makeAnchor('https://example.com/nested')
+    const span = document.createElement('span')
+    a.appendChild(span)
+    expect(getExternalUrlFromClick(clickEvent(span))).toBe(
+      'https://example.com/nested'
+    )
+  })
+
+  it('ignores same-origin (in-app) links', () => {
+    const a = makeAnchor(`${window.location.origin}/internal`)
+    expect(getExternalUrlFromClick(clickEvent(a))).toBeNull()
+  })
+
+  it('ignores clicks that are not on an anchor', () => {
+    const div = document.createElement('div')
+    document.body.appendChild(div)
+    expect(getExternalUrlFromClick(clickEvent(div))).toBeNull()
+  })
+
+  it('ignores anchors without an href', () => {
+    const a = document.createElement('a')
+    document.body.appendChild(a)
+    expect(getExternalUrlFromClick(clickEvent(a))).toBeNull()
+  })
+
+  it('ignores non-primary-button clicks', () => {
+    const a = makeAnchor('https://example.com/')
+    expect(getExternalUrlFromClick(clickEvent(a, { button: 1 }))).toBeNull()
+  })
+
+  it('ignores modified clicks (cmd/ctrl/alt/shift)', () => {
+    const a = makeAnchor('https://example.com/')
+    expect(getExternalUrlFromClick(clickEvent(a, { metaKey: true }))).toBeNull()
+    expect(getExternalUrlFromClick(clickEvent(a, { ctrlKey: true }))).toBeNull()
+    expect(getExternalUrlFromClick(clickEvent(a, { altKey: true }))).toBeNull()
+    expect(
+      getExternalUrlFromClick(clickEvent(a, { shiftKey: true }))
+    ).toBeNull()
+  })
+
+  it('ignores clicks that have already been handled', () => {
+    const a = makeAnchor('https://example.com/')
+    expect(
+      getExternalUrlFromClick(clickEvent(a, { defaultPrevented: true }))
+    ).toBeNull()
+  })
+})

--- a/src/lib/external-links.test.ts
+++ b/src/lib/external-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { getExternalUrlFromClick } from './external-links'
+import { classifyLinkClick } from './external-links'
 
 /**
  * Build a minimal MouseEvent-like object whose `target` is a real DOM element,
@@ -33,72 +33,108 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-describe('getExternalUrlFromClick', () => {
-  it('returns the URL for an external https link', () => {
+describe('classifyLinkClick', () => {
+  it('opens external https links', () => {
     const a = makeAnchor('https://example.com/page')
-    expect(getExternalUrlFromClick(clickEvent(a))).toBe(
-      'https://example.com/page'
-    )
+    expect(classifyLinkClick(clickEvent(a))).toEqual({
+      type: 'open',
+      url: 'https://example.com/page',
+    })
   })
 
-  it('returns the URL for an external http link', () => {
+  it('opens external http links', () => {
     const a = makeAnchor('http://example.com/')
-    expect(getExternalUrlFromClick(clickEvent(a))).toBe('http://example.com/')
+    expect(classifyLinkClick(clickEvent(a))).toEqual({
+      type: 'open',
+      url: 'http://example.com/',
+    })
   })
 
-  it('returns the URL for mailto and tel links', () => {
+  it('opens mailto and tel links', () => {
     const mail = makeAnchor('mailto:hi@danny.is')
-    expect(getExternalUrlFromClick(clickEvent(mail))).toBe('mailto:hi@danny.is')
+    expect(classifyLinkClick(clickEvent(mail))).toEqual({
+      type: 'open',
+      url: 'mailto:hi@danny.is',
+    })
 
     const tel = makeAnchor('tel:+15551234567')
-    expect(getExternalUrlFromClick(clickEvent(tel))).toBe('tel:+15551234567')
+    expect(classifyLinkClick(clickEvent(tel))).toEqual({
+      type: 'open',
+      url: 'tel:+15551234567',
+    })
   })
 
   it('resolves clicks on elements nested inside the anchor', () => {
     const a = makeAnchor('https://example.com/nested')
     const span = document.createElement('span')
     a.appendChild(span)
-    expect(getExternalUrlFromClick(clickEvent(span))).toBe(
-      'https://example.com/nested'
-    )
+    expect(classifyLinkClick(clickEvent(span))).toEqual({
+      type: 'open',
+      url: 'https://example.com/nested',
+    })
+  })
+
+  it('blocks unsafe / webview-navigating schemes', () => {
+    expect(
+      classifyLinkClick(clickEvent(makeAnchor('javascript:alert(1)')))
+    ).toEqual({ type: 'block' })
+    expect(
+      classifyLinkClick(clickEvent(makeAnchor('file:///etc/passwd')))
+    ).toEqual({ type: 'block' })
+    expect(
+      classifyLinkClick(clickEvent(makeAnchor('data:text/html,<h1>hi</h1>')))
+    ).toEqual({ type: 'block' })
   })
 
   it('ignores same-origin (in-app) links', () => {
     const a = makeAnchor(`${window.location.origin}/internal`)
-    expect(getExternalUrlFromClick(clickEvent(a))).toBeNull()
+    expect(classifyLinkClick(clickEvent(a))).toEqual({ type: 'ignore' })
+  })
+
+  it('ignores same-origin hash links', () => {
+    const a = makeAnchor(`${window.location.origin}/#section`)
+    expect(classifyLinkClick(clickEvent(a))).toEqual({ type: 'ignore' })
   })
 
   it('ignores clicks that are not on an anchor', () => {
     const div = document.createElement('div')
     document.body.appendChild(div)
-    expect(getExternalUrlFromClick(clickEvent(div))).toBeNull()
+    expect(classifyLinkClick(clickEvent(div))).toEqual({ type: 'ignore' })
   })
 
   it('ignores anchors without an href', () => {
     const a = document.createElement('a')
     document.body.appendChild(a)
-    expect(getExternalUrlFromClick(clickEvent(a))).toBeNull()
+    expect(classifyLinkClick(clickEvent(a))).toEqual({ type: 'ignore' })
   })
 
   it('ignores non-primary-button clicks', () => {
     const a = makeAnchor('https://example.com/')
-    expect(getExternalUrlFromClick(clickEvent(a, { button: 1 }))).toBeNull()
+    expect(classifyLinkClick(clickEvent(a, { button: 1 }))).toEqual({
+      type: 'ignore',
+    })
   })
 
   it('ignores modified clicks (cmd/ctrl/alt/shift)', () => {
     const a = makeAnchor('https://example.com/')
-    expect(getExternalUrlFromClick(clickEvent(a, { metaKey: true }))).toBeNull()
-    expect(getExternalUrlFromClick(clickEvent(a, { ctrlKey: true }))).toBeNull()
-    expect(getExternalUrlFromClick(clickEvent(a, { altKey: true }))).toBeNull()
-    expect(
-      getExternalUrlFromClick(clickEvent(a, { shiftKey: true }))
-    ).toBeNull()
+    expect(classifyLinkClick(clickEvent(a, { metaKey: true }))).toEqual({
+      type: 'ignore',
+    })
+    expect(classifyLinkClick(clickEvent(a, { ctrlKey: true }))).toEqual({
+      type: 'ignore',
+    })
+    expect(classifyLinkClick(clickEvent(a, { altKey: true }))).toEqual({
+      type: 'ignore',
+    })
+    expect(classifyLinkClick(clickEvent(a, { shiftKey: true }))).toEqual({
+      type: 'ignore',
+    })
   })
 
   it('ignores clicks that have already been handled', () => {
     const a = makeAnchor('https://example.com/')
     expect(
-      getExternalUrlFromClick(clickEvent(a, { defaultPrevented: true }))
-    ).toBeNull()
+      classifyLinkClick(clickEvent(a, { defaultPrevented: true }))
+    ).toEqual({ type: 'ignore' })
   })
 })

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -1,52 +1,75 @@
 /**
- * Shared logic for routing external links to the OS default browser.
+ * Shared logic for routing link clicks safely in a Tauri webview.
  *
  * In a Tauri webview, a plain `<a href="https://…">` click navigates the app
  * window itself — replacing the app with the website and leaving no way back.
  * Any external link, wherever it is rendered (release notes, injected HTML,
  * etc.), should instead open in the user's default browser so the app keeps
- * feeling like a native Mac app.
+ * feeling like a native Mac app. Likewise, links using webview-navigating or
+ * script schemes (`data:`, `file:`, `javascript:`) must never replace the app.
  *
  * This module provides the pure decision logic; `useExternalLinkHandler` wires
  * it up as a single app-wide click listener.
  */
 
+// Protocols that should always be handed to the OS default handler.
 const EXTERNAL_PROTOCOLS = new Set(['mailto:', 'tel:'])
 
+// Protocols that must never navigate the webview. We can't meaningfully open
+// these externally, so the safe action is to block the click entirely.
+const BLOCKED_PROTOCOLS = new Set(['javascript:', 'data:', 'file:'])
+
 /**
- * Given a click event, determine whether it targets an external link that
- * should be opened in the OS browser rather than navigated to in the webview.
- *
- * Returns the absolute URL to open, or `null` when the click should be left
- * to its default behaviour (not an anchor, an in-app link, a modified click,
- * or already handled).
+ * What to do with a link click:
+ * - `open`: open `url` in the OS default browser (don't navigate the webview)
+ * - `block`: prevent navigation but do nothing else (unsafe/webview-only scheme)
+ * - `ignore`: leave the click to its default behaviour
  */
-export const getExternalUrlFromClick = (event: MouseEvent): string | null => {
+export type LinkClickAction =
+  | { type: 'open'; url: string }
+  | { type: 'block' }
+  | { type: 'ignore' }
+
+const IGNORE: LinkClickAction = { type: 'ignore' }
+
+/**
+ * Classify a click event against the nearest anchor, deciding whether it should
+ * open externally, be blocked, or be ignored. Modified clicks, non-anchor
+ * clicks, and in-app (same-origin) links are ignored.
+ */
+export const classifyLinkClick = (event: MouseEvent): LinkClickAction => {
   // Only handle unmodified primary-button clicks that nothing else has handled.
-  if (event.defaultPrevented) return null
-  if (event.button !== 0) return null
+  if (event.defaultPrevented) return IGNORE
+  if (event.button !== 0) return IGNORE
   if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
-    return null
+    return IGNORE
   }
 
   const target = event.target
-  if (!(target instanceof Element)) return null
+  if (!(target instanceof Element)) return IGNORE
 
   const anchor = target.closest('a')
-  if (!anchor) return null
+  if (!anchor) return IGNORE
 
   // `href` is the property (resolved to absolute), not the raw attribute.
   const href = anchor.href
-  if (!href) return null
+  if (!href) return IGNORE
 
   // `mailto:`/`tel:` always go to the OS handler.
-  if (EXTERNAL_PROTOCOLS.has(anchor.protocol)) return href
+  if (EXTERNAL_PROTOCOLS.has(anchor.protocol))
+    return { type: 'open', url: href }
 
   // For http(s), only treat cross-origin links as external. Same-origin links
   // are in-app navigation (or the dev server) and must be left alone.
   if (anchor.protocol === 'http:' || anchor.protocol === 'https:') {
-    if (anchor.origin !== window.location.origin) return href
+    return anchor.origin !== window.location.origin
+      ? { type: 'open', url: href }
+      : IGNORE
   }
 
-  return null
+  // Schemes that would navigate the webview away from the app (or run script)
+  // are blocked rather than allowed through.
+  if (BLOCKED_PROTOCOLS.has(anchor.protocol)) return { type: 'block' }
+
+  return IGNORE
 }

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared logic for routing external links to the OS default browser.
+ *
+ * In a Tauri webview, a plain `<a href="https://…">` click navigates the app
+ * window itself — replacing the app with the website and leaving no way back.
+ * Any external link, wherever it is rendered (release notes, injected HTML,
+ * etc.), should instead open in the user's default browser so the app keeps
+ * feeling like a native Mac app.
+ *
+ * This module provides the pure decision logic; `useExternalLinkHandler` wires
+ * it up as a single app-wide click listener.
+ */
+
+const EXTERNAL_PROTOCOLS = new Set(['mailto:', 'tel:'])
+
+/**
+ * Given a click event, determine whether it targets an external link that
+ * should be opened in the OS browser rather than navigated to in the webview.
+ *
+ * Returns the absolute URL to open, or `null` when the click should be left
+ * to its default behaviour (not an anchor, an in-app link, a modified click,
+ * or already handled).
+ */
+export const getExternalUrlFromClick = (event: MouseEvent): string | null => {
+  // Only handle unmodified primary-button clicks that nothing else has handled.
+  if (event.defaultPrevented) return null
+  if (event.button !== 0) return null
+  if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+    return null
+  }
+
+  const target = event.target
+  if (!(target instanceof Element)) return null
+
+  const anchor = target.closest('a')
+  if (!anchor) return null
+
+  // `href` is the property (resolved to absolute), not the raw attribute.
+  const href = anchor.href
+  if (!href) return null
+
+  // `mailto:`/`tel:` always go to the OS handler.
+  if (EXTERNAL_PROTOCOLS.has(anchor.protocol)) return href
+
+  // For http(s), only treat cross-origin links as external. Same-origin links
+  // are in-app navigation (or the dev server) and must be left alone.
+  if (anchor.protocol === 'http:' || anchor.protocol === 'https:') {
+    if (anchor.origin !== window.location.origin) return href
+  }
+
+  return null
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External links now open in your system’s default browser from within the app.
  * Added handling for `http/https`, `mailto:`, and `tel:` links.
* **Bug Fixes**
  * Same-site links continue to use in-app navigation.
  * Modified clicks and already-handled events are ignored to prevent unexpected navigation.
  * Unsafe schemes (for example `javascript:`, `data:`, `file:`) are blocked.
* **Tests**
  * Expanded automated coverage for external-link detection, including nested targets and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->